### PR TITLE
Add Tuplet

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,3 +1,3 @@
-alias Exactly.{Chord, Duration, Note, Pitch, Rest, Skip, Voice}
+alias Exactly.{Chord, Duration, Note, Pitch, Rest, Skip, Tuplet, Voice}
 
 import Exactly, only: [to_lilypond: 1]

--- a/lib/exactly.ex
+++ b/lib/exactly.ex
@@ -4,5 +4,13 @@ defmodule Exactly do
   using Elixir as the building blocks.
   """
 
+  @type score_element ::
+          Exactly.Chord.t()
+          | Exactly.Note.t()
+          | Exactly.Rest.t()
+          | Exactly.Skip.t()
+          | Exactly.Tuplet.t()
+          | Exactly.Voice.t()
+
   def to_lilypond(x), do: Exactly.ToLilypond.to_lilypond(x)
 end

--- a/lib/exactly/tuplet.ex
+++ b/lib/exactly/tuplet.ex
@@ -1,0 +1,58 @@
+defmodule Exactly.Tuplet do
+  @moduledoc """
+  Models Lilypond `TimeScaledMusic`
+  """
+
+  defstruct [:multiplier, :elements]
+
+  @type t :: %__MODULE__{
+          multiplier: {pos_integer(), pos_integer()},
+          elements: [Exactly.score_element()]
+        }
+
+  def new(multiplier, elements \\ []) do
+    %__MODULE__{
+      multiplier: Exactly.Utils.to_fraction(multiplier),
+      elements: elements
+    }
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{multiplier: {n, d}, elements: elements}, _opts) do
+      concat([
+        "#Exactly.Tuplet<",
+        "(#{n}/#{d}) ",
+        inspect_elements(elements),
+        ">"
+      ])
+    end
+
+    defp inspect_elements(elements) do
+      [
+        "{",
+        Enum.map(elements, &to_string/1),
+        "}"
+      ]
+      |> List.flatten()
+      |> Enum.join(" ")
+    end
+  end
+
+  defimpl Exactly.ToLilypond do
+    import Exactly.Lilypond.Utils
+
+    def to_lilypond(%@for{multiplier: {n, d}, elements: elements}) do
+      [
+        "\\tuplet #{d}/#{n} {",
+        Enum.map(elements, fn el ->
+          el |> @protocol.to_lilypond() |> indent()
+        end),
+        "}"
+      ]
+      |> List.flatten()
+      |> Enum.join("\n")
+    end
+  end
+end

--- a/test/exactly/tuplet_test.exs
+++ b/test/exactly/tuplet_test.exs
@@ -1,0 +1,52 @@
+defmodule Exactly.TupletTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, Pitch, Tuplet}
+
+  describe "new/2" do
+    test "takes a multiplier and a list of elements" do
+      tuplet =
+        Tuplet.new(2 / 3, [
+          Note.new(),
+          Note.new(Pitch.new(1, 0, 0)),
+          Note.new(Pitch.new(2, -0.5, 0))
+        ])
+
+      assert tuplet.multiplier == {2, 3}
+      assert length(tuplet.elements) == 3
+    end
+  end
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the tuplet" do
+      tuplet =
+        Tuplet.new(2 / 3, [
+          Note.new(),
+          Note.new(Pitch.new(1, 0, 0)),
+          Note.new(Pitch.new(2, -0.5, 0))
+        ])
+
+      assert inspect(tuplet) == "#Exactly.Tuplet<(2/3) { c'4 d'4 ef'4 }>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the tuplet" do
+      tuplet =
+        Tuplet.new(2 / 3, [
+          Note.new(),
+          Note.new(Pitch.new(1, 0, 0)),
+          Note.new(Pitch.new(2, -0.5, 0))
+        ])
+
+      assert Exactly.to_lilypond(tuplet) ==
+               String.trim("""
+               \\tuplet 3/2 {
+                 c'4
+                 d'4
+                 ef'4
+               }
+               """)
+    end
+  end
+end


### PR DESCRIPTION
* struct
* inspect
* to_lilypond

Also
==

* Add `Exactly.score_element` type to store Exactly structs that can be
  represented as a root element on a score
