### PR TITLE
Add additional output formatting

### DIFF
--- a/lib/exactly/book.ex
+++ b/lib/exactly/book.ex
@@ -1,0 +1,53 @@
+defmodule Exactly.Book do
+  @moduledoc """
+  Models a lilypond top-level \\book context
+  """
+
+  alias Exactly.{Bookpart, Header}
+
+  defstruct [:bookparts, header: nil]
+
+  @type t :: %__MODULE__{
+          bookparts: [Bookpart.t()],
+          header: Header.t() | nil
+        }
+
+  def new(bookparts \\ []) do
+    %__MODULE__{bookparts: bookparts}
+  end
+
+  def set_header(%__MODULE__{} = book, %Header{} = header) do
+    %__MODULE__{book | header: header}
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{bookparts: bookparts}, _opts) do
+      concat([
+        "#Exactly.Book<{",
+        " #{length(bookparts)} ",
+        "}>"
+      ])
+    end
+  end
+
+  defimpl Exactly.ToLilypond do
+    import Exactly.Lilypond.Utils
+
+    def to_lilypond(%@for{bookparts: bookparts, header: header}) do
+      [
+        "\\book {",
+        build_header(header),
+        Enum.map(bookparts, fn bookpart ->
+          bookpart |> @protocol.to_lilypond() |> indent()
+        end),
+        "}"
+      ]
+      |> concat()
+    end
+
+    defp build_header(nil), do: nil
+    defp build_header(%Header{} = header), do: indent(@protocol.to_lilypond(header)) <> "\n"
+  end
+end

--- a/lib/exactly/bookpart.ex
+++ b/lib/exactly/bookpart.ex
@@ -1,0 +1,53 @@
+defmodule Exactly.Bookpart do
+  @moduledoc """
+  Models a Lilypond \\bookpart context
+  """
+
+  alias Exactly.{Header, Score}
+
+  defstruct [:scores, header: nil]
+
+  @type t :: %__MODULE__{
+          scores: [Score.t()],
+          header: Header.t() | nil
+        }
+
+  def new(scores \\ []) do
+    %__MODULE__{scores: scores}
+  end
+
+  def set_header(%__MODULE__{} = bookpart, %Header{} = header) do
+    %__MODULE__{bookpart | header: header}
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{scores: scores}, _opts) do
+      concat([
+        "#Exactly.Bookpart<{",
+        " #{length(scores)} ",
+        "}>"
+      ])
+    end
+  end
+
+  defimpl Exactly.ToLilypond do
+    import Exactly.Lilypond.Utils
+
+    def to_lilypond(%@for{scores: scores, header: header}) do
+      [
+        "\\bookpart {",
+        build_header(header),
+        Enum.map(scores, fn score ->
+          score |> @protocol.to_lilypond() |> indent()
+        end),
+        "}"
+      ]
+      |> concat()
+    end
+
+    defp build_header(nil), do: nil
+    defp build_header(%Header{} = header), do: indent(@protocol.to_lilypond(header))
+  end
+end

--- a/lib/exactly/chord.ex
+++ b/lib/exactly/chord.ex
@@ -56,8 +56,7 @@ defmodule Exactly.Chord do
         end),
         ">#{@protocol.to_lilypond(duration)}"
       ]
-      |> List.flatten()
-      |> Enum.join("\n")
+      |> concat()
     end
   end
 end

--- a/lib/exactly/container.ex
+++ b/lib/exactly/container.ex
@@ -47,8 +47,7 @@ defmodule Exactly.Container do
         end),
         close
       ]
-      |> List.flatten()
-      |> Enum.join("\n")
+      |> concat()
     end
   end
 end

--- a/lib/exactly/header.ex
+++ b/lib/exactly/header.ex
@@ -48,8 +48,7 @@ defmodule Exactly.Header do
         format_settings(settings),
         "}"
       ]
-      |> List.flatten()
-      |> Enum.join("\n")
+      |> concat()
     end
 
     defp format_settings(settings) do

--- a/lib/exactly/lilypond/file.ex
+++ b/lib/exactly/lilypond/file.ex
@@ -9,21 +9,46 @@ defmodule Exactly.Lilypond.File do
   # Allow us to pass an alternative command in testing to avoid needing to install Lilypond in CI
   @runner Application.compile_env(:exactly, :runner, &:os.cmd/1)
 
-  alias Exactly.Container
+  alias Exactly.{Container, Header}
+  alias Exactly.Lilypond.Utils, as: LilypondUtils
 
-  defstruct [:content, :source_path, :output_path]
+  defstruct [:content, :source_path, :output_path, header: nil]
+
+  @type t :: %__MODULE__{
+          content: any(),
+          source_path: String.t() | nil,
+          output_path: String.t() | nil,
+          header: Header.t() | nil
+        }
 
   def from(%{elements: _} = content) do
     %__MODULE__{content: content}
+  end
+
+  def from(content_list) when is_list(content_list) do
+    wrapped_contents =
+      Enum.map(content_list, fn
+        %{elements: _} = content -> content
+        content -> Container.new([content])
+      end)
+
+    %__MODULE__{content: wrapped_contents}
   end
 
   def from(content) do
     %__MODULE__{content: Container.new([content])}
   end
 
-  def save(%__MODULE__{content: content} = file, source_path \\ generate_source_path()) do
+  def set_header(%__MODULE__{} = file, %Header{} = header) do
+    %__MODULE__{file | header: header}
+  end
+
+  def save(
+        %__MODULE__{content: content, header: header} = file,
+        source_path \\ generate_source_path()
+      ) do
     source_path = Path.expand(source_path)
-    lilypond_contents = build_lilypond_contents(content)
+    lilypond_contents = build_lilypond_contents(content, header)
     :ok = File.write(source_path, lilypond_contents)
     %{file | source_path: source_path}
   end
@@ -54,17 +79,26 @@ defmodule Exactly.Lilypond.File do
     |> then(&@runner.(&1))
   end
 
-  defp build_lilypond_contents(content) do
+  defp build_lilypond_contents(content, header) do
     [
       """
       \\version "#{Exactly.lilypond_version()}"
       \\language "english"
       """,
-      Exactly.to_lilypond(content)
+      build_header(header),
+      build_content(content)
     ]
-    |> List.flatten()
-    |> Enum.join("\n")
+    |> LilypondUtils.concat()
   end
+
+  defp build_header(nil), do: nil
+  defp build_header(%Header{} = header), do: Exactly.to_lilypond(header) <> "\n"
+
+  defp build_content(content) when is_list(content) do
+    Enum.map_join(content, "\n\n", &Exactly.to_lilypond/1)
+  end
+
+  defp build_content(content), do: build_content([content])
 
   defp generate_source_path do
     [

--- a/lib/exactly/lilypond/utils.ex
+++ b/lib/exactly/lilypond/utils.ex
@@ -1,10 +1,25 @@
 defmodule Exactly.Lilypond.Utils do
   @moduledoc false
 
-  def indent(s) do
+  def indent(s, depth \\ 1)
+  def indent(nil, _), do: nil
+
+  def indent(s, depth) when is_bitstring(s) do
     s
-    |> String.split("\n", trim: true)
-    |> Enum.map_join("\n", &"  #{&1}")
+    |> String.trim()
+    |> String.split("\n")
+    # |> Enum.map_join("\n", &"#{String.duplicate("  ", depth)}#{&1}")
+    |> Enum.map_join("\n", fn
+      "" -> ""
+      s -> "#{String.duplicate("  ", depth)}#{s}"
+    end)
+  end
+
+  def concat(l, joiner \\ "\n") do
+    l
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(joiner)
   end
 
   def brackets(false), do: {"{", "}"}

--- a/lib/exactly/staff.ex
+++ b/lib/exactly/staff.ex
@@ -49,8 +49,7 @@ defmodule Exactly.Staff do
         end),
         close
       ]
-      |> List.flatten()
-      |> Enum.join("\n")
+      |> concat()
     end
   end
 end

--- a/lib/exactly/staff_group.ex
+++ b/lib/exactly/staff_group.ex
@@ -49,8 +49,7 @@ defmodule Exactly.StaffGroup do
         end),
         close
       ]
-      |> List.flatten()
-      |> Enum.join("\n")
+      |> concat()
     end
   end
 end

--- a/lib/exactly/to_lilypond.ex
+++ b/lib/exactly/to_lilypond.ex
@@ -1,3 +1,8 @@
 defprotocol Exactly.ToLilypond do
   def to_lilypond(x)
 end
+
+defimpl Exactly.ToLilypond, for: Atom do
+  def to_lilypond(nil), do: nil
+  def to_lilypond(atom), do: to_string(atom)
+end

--- a/lib/exactly/tuplet.ex
+++ b/lib/exactly/tuplet.ex
@@ -51,8 +51,7 @@ defmodule Exactly.Tuplet do
         end),
         "}"
       ]
-      |> List.flatten()
-      |> Enum.join("\n")
+      |> concat()
     end
   end
 end

--- a/lib/exactly/voice.ex
+++ b/lib/exactly/voice.ex
@@ -49,8 +49,7 @@ defmodule Exactly.Voice do
         end),
         close
       ]
-      |> List.flatten()
-      |> Enum.join("\n")
+      |> concat()
     end
   end
 end

--- a/test/exactly/book_test.exs
+++ b/test/exactly/book_test.exs
@@ -1,0 +1,81 @@
+defmodule Exactly.BookTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Book, Bookpart, Header, Note, Pitch, Score}
+
+  setup do
+    score1 =
+      Score.new([Note.new()])
+      |> Score.set_header(Header.new(title: "Score 1"))
+
+    score2 = Score.new([Note.new(Pitch.new(1))])
+
+    bookpart1 =
+      Bookpart.new([score1])
+      |> Bookpart.set_header(Header.new(title: "Bookpart1"))
+
+    {
+      :ok,
+      bookpart1: bookpart1, bookpart2: Bookpart.new([score2])
+    }
+  end
+
+  describe "new/1" do
+    test "takes a list of bookpart structs", context do
+      book = Book.new([context.bookpart1, context.bookpart2])
+
+      assert length(book.bookparts) == 2
+      assert is_nil(book.header)
+    end
+  end
+
+  describe "set_header/2" do
+    test "can add a header", context do
+      book =
+        Book.new([context.bookpart1, context.bookpart2])
+        |> Book.set_header(Header.new(title: "Book 1"))
+
+      assert book.header == %Header{settings: [title: "Book 1"]}
+    end
+  end
+
+  describe "inspect/1" do
+    test "returns an Iex-ready represenation for the book", context do
+      book = Book.new([context.bookpart1, context.bookpart2])
+
+      assert inspect(book) == "#Exactly.Book<{ 2 }>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the book", context do
+      book = Book.new([context.bookpart1, context.bookpart2])
+
+      assert Exactly.to_lilypond(book) ==
+               String.trim("""
+               \\book {
+                 \\bookpart {
+                   \\header {
+                     title = "Bookpart1"
+                   }
+                   \\score {
+                     \\header {
+                       title = "Score 1"
+                     }
+                     <<
+                       c4
+                     >>
+                   }
+                 }
+                 \\bookpart {
+                   \\score {
+                     <<
+                       d4
+                     >>
+                   }
+                 }
+               }
+               """)
+    end
+  end
+end

--- a/test/exactly/bookpart_test.exs
+++ b/test/exactly/bookpart_test.exs
@@ -1,0 +1,66 @@
+defmodule Exactly.BookpartTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Bookpart, Header, Note, Pitch, Score}
+
+  setup do
+    {
+      :ok,
+      score1: Score.new([Note.new()]), score2: Score.new([Note.new(Pitch.new(1))])
+    }
+  end
+
+  describe "new/1" do
+    test "takes a list of score structs", context do
+      bookpart = Bookpart.new([context.score1, context.score2])
+
+      assert length(bookpart.scores) == 2
+      assert is_nil(bookpart.header)
+    end
+  end
+
+  describe "set_header/2" do
+    test "can add a header", context do
+      bookpart =
+        Bookpart.new([context.score1, context.score2])
+        |> Bookpart.set_header(Header.new(title: "Bookpart 1"))
+
+      assert bookpart.header == %Header{settings: [title: "Bookpart 1"]}
+    end
+  end
+
+  describe "inspect/1" do
+    test "returns an Iex-ready represenation for the bookpart", context do
+      bookpart = Bookpart.new([context.score1, context.score2])
+
+      assert inspect(bookpart) == "#Exactly.Bookpart<{ 2 }>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the bookpart", context do
+      bookpart =
+        Bookpart.new([context.score1, context.score2])
+        |> Bookpart.set_header(Header.new(title: "Bookpart Test"))
+
+      assert Exactly.to_lilypond(bookpart) ==
+               String.trim("""
+               \\bookpart {
+                 \\header {
+                   title = "Bookpart Test"
+                 }
+                 \\score {
+                   <<
+                     c4
+                   >>
+                 }
+                 \\score {
+                   <<
+                     d4
+                   >>
+                 }
+               }
+               """)
+    end
+  end
+end

--- a/test/exactly/score_test.exs
+++ b/test/exactly/score_test.exs
@@ -1,7 +1,7 @@
 defmodule Exactly.ScoreTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.{Duration, Note, Pitch, Rest, Score, Staff, StaffGroup}
+  alias Exactly.{Duration, Header, Note, Pitch, Rest, Score, Staff, StaffGroup}
 
   setup do
     score =
@@ -53,18 +53,48 @@ defmodule Exactly.ScoreTest do
       assert Exactly.to_lilypond(score) ==
                String.trim("""
                \\score {
-                 \\context Staff = "Flute" {
-                   c4
-                   ef4
-                 }
-                 \\context StaffGroup = "Strings" <<
-                   \\context Staff = "Violin" {
-                     r4
+                 <<
+                   \\context Staff = "Flute" {
                      c4
+                     ef4
                    }
-                   \\context Staff = "Cello" {
-                     c,2
+                   \\context StaffGroup = "Strings" <<
+                     \\context Staff = "Violin" {
+                       r4
+                       c4
+                     }
+                     \\context Staff = "Cello" {
+                       c,2
+                     }
+                   >>
+                 >>
+               }
+               """)
+    end
+
+    test "header is correctly nested", %{score: score} do
+      score = Score.set_header(score, Header.new(piece: "Trio"))
+
+      assert Exactly.to_lilypond(score) ==
+               String.trim("""
+               \\score {
+                 \\header {
+                   piece = "Trio"
+                 }
+                 <<
+                   \\context Staff = "Flute" {
+                     c4
+                     ef4
                    }
+                   \\context StaffGroup = "Strings" <<
+                     \\context Staff = "Violin" {
+                       r4
+                       c4
+                     }
+                     \\context Staff = "Cello" {
+                       c,2
+                     }
+                   >>
                  >>
                }
                """)


### PR DESCRIPTION
- Add Bookpart and Book
- Allow attaching a Header to a Score, Bookpart, Book, or Lilypond.File
- Can create a Lilypond.File from a list of top-level contexts
