### PR TITLE
Refactor Lilypond.File to correctly handle multiple output files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         elixir: ["1.14.5"]
 
     steps:
+      - name: Install lilypond
+        run: sudo apt-get install lilypond
+
       - uses: actions/checkout@v3
 
       - name: Set up Elixir
@@ -56,4 +59,4 @@ jobs:
           mix format --check-formatted
 
       - name: Run tests
-        run: mix test
+        run: mix test --include lilypond

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,5 @@
 import Config
 
-config :exactly, :runner, &IO.puts/1
-
 config :mix_test_watch,
   tasks: [
     "test --include lilypond",

--- a/test/exactly_test.exs
+++ b/test/exactly_test.exs
@@ -1,22 +1,5 @@
 defmodule ExactlyTest do
   use ExUnit.Case
-  import ExUnit.CaptureIO
 
   doctest Exactly
-
-  alias Exactly.Note
-
-  describe "show/1" do
-    test "saves, compiles and opens an exactly score element" do
-      output =
-        capture_io(fn ->
-          Note.new() |> Exactly.show()
-        end)
-
-      assert Regex.match?(
-               ~r/#{Exactly.lilypond_executable()} -s -o (.*) \1\.ly\nopen \1\.pdf/,
-               output
-             )
-    end
-  end
 end


### PR DESCRIPTION
- Ensure multiple file outputs are stored in the Lilypond.File struct correctly
- Move all lilypond-involved tests under `@tag :lilypond`
- Remove custom runner
- Install `lilypond` in GHA