### PR TITLE
Start implementing attachments

### DIFF
--- a/lib/exactly.ex
+++ b/lib/exactly.ex
@@ -18,6 +18,7 @@ defmodule Exactly do
           | Exactly.Tuplet.t()
           | Exactly.Voice.t()
 
+  alias Exactly.Attachment
   alias Exactly.Lilypond.File, as: LilypondFile
 
   def to_lilypond(x), do: Exactly.ToLilypond.to_lilypond(x)
@@ -28,5 +29,9 @@ defmodule Exactly do
     |> LilypondFile.save()
     |> LilypondFile.compile()
     |> LilypondFile.show()
+  end
+
+  def attach(%{attachments: _} = target, attachable, opts \\ []) do
+    %{target | attachments: [Attachment.new(attachable, opts) | target.attachments]}
   end
 end

--- a/lib/exactly/articulation.ex
+++ b/lib/exactly/articulation.ex
@@ -1,0 +1,26 @@
+defmodule Exactly.Articulation do
+  @moduledoc """
+  Models a Lilypond articulation attachment
+  """
+
+  use Exactly.Attachable, fields: [:name]
+
+  def new(name) do
+    %__MODULE__{
+      name: name,
+      components: [after: ["\\#{name}"]]
+    }
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{name: name}, _opts) do
+      concat([
+        "#Exactly.Articulation<",
+        to_string(name),
+        ">"
+      ])
+    end
+  end
+end

--- a/lib/exactly/attachable.ex
+++ b/lib/exactly/attachable.ex
@@ -1,0 +1,27 @@
+defmodule Exactly.Attachable do
+  @moduledoc """
+  Shared functionality for attachable objects
+
+    * articulations
+    * clefs
+    * time signatures
+    * key signatures
+    * slurs
+    * beams
+    * dynamics
+    * etc.
+  """
+
+  defmacro __using__(opts) do
+    fields = Keyword.get(opts, :fields, [])
+    has_direction = Keyword.get(opts, :has_direction, true)
+
+    quote do
+      defstruct [unquote_splicing(fields), :components]
+
+      defimpl Exactly.HasDirection do
+        def has_direction(_), do: unquote(has_direction)
+      end
+    end
+  end
+end

--- a/lib/exactly/attachment.ex
+++ b/lib/exactly/attachment.ex
@@ -1,0 +1,34 @@
+defmodule Exactly.Attachment do
+  @moduledoc """
+  Acts as a wrapper for attaching an attachable object to a target
+  """
+
+  defstruct [:attachable, :priority, :direction]
+
+  def new(attachable, opts \\ []) do
+    %__MODULE__{
+      attachable: attachable,
+      priority: Keyword.get(opts, :priority, 0),
+      direction: attachable_direction(attachable, opts)
+    }
+  end
+
+  def prepared_components(%__MODULE__{attachable: %{components: components}, direction: direction}) do
+    components
+    |> Enum.map(fn {k, v} ->
+      {k, Enum.map(v, &with_direction(&1, direction))}
+    end)
+  end
+
+  defp with_direction(str, nil), do: str
+  defp with_direction(str, :neutral), do: "- #{str}"
+  defp with_direction(str, :up), do: "^ #{str}"
+  defp with_direction(str, :down), do: "_ #{str}"
+
+  defp attachable_direction(attachable, opts) do
+    case Exactly.HasDirection.has_direction(attachable) do
+      true -> Keyword.get(opts, :direction, :neutral)
+      false -> nil
+    end
+  end
+end

--- a/lib/exactly/breath_mark.ex
+++ b/lib/exactly/breath_mark.ex
@@ -1,0 +1,17 @@
+defmodule Exactly.BreathMark do
+  @moduledoc """
+  Models a Lilypond breath mark
+  """
+
+  use Exactly.Attachable, has_direction: false
+
+  def new do
+    %__MODULE__{
+      components: [after: ["\\breathe"]]
+    }
+  end
+
+  defimpl Inspect do
+    def inspect(%@for{}, _opts), do: "#Exactly.BreathMark<>"
+  end
+end

--- a/lib/exactly/has_direction.ex
+++ b/lib/exactly/has_direction.ex
@@ -1,0 +1,8 @@
+defprotocol Exactly.HasDirection do
+  @fallback_to_any true
+  def has_direction(obj)
+end
+
+defimpl Exactly.HasDirection, for: Any do
+  def has_direction(_), do: true
+end

--- a/lib/exactly/laissez_vibrer.ex
+++ b/lib/exactly/laissez_vibrer.ex
@@ -1,0 +1,17 @@
+defmodule Exactly.LaissezVibrer do
+  @moduledoc """
+  Models a laissez vibrer tie
+  """
+
+  use Exactly.Attachable
+
+  def new do
+    %__MODULE__{
+      components: [after: ["\\laissezVibrer"]]
+    }
+  end
+
+  defimpl Inspect do
+    def inspect(%@for{}, _opts), do: "#Exactly.LaissezVibrer<>"
+  end
+end

--- a/lib/exactly/lilypond/utils.ex
+++ b/lib/exactly/lilypond/utils.ex
@@ -1,6 +1,8 @@
 defmodule Exactly.Lilypond.Utils do
   @moduledoc false
 
+  alias Exactly.Attachment
+
   def indent(s, depth \\ 1)
   def indent(nil, _), do: nil
 
@@ -8,7 +10,6 @@ defmodule Exactly.Lilypond.Utils do
     s
     |> String.trim()
     |> String.split("\n")
-    # |> Enum.map_join("\n", &"#{String.duplicate("  ", depth)}#{&1}")
     |> Enum.map_join("\n", fn
       "" -> ""
       s -> "#{String.duplicate("  ", depth)}#{s}"
@@ -39,5 +40,15 @@ defmodule Exactly.Lilypond.Utils do
 
   def brackets(context, name, true) do
     {"\\context #{context} = \"#{name}\" <<", ">>"}
+  end
+
+  def attachments_for(%{attachments: attachments}) do
+    attachments
+    |> Enum.reverse()
+    |> Enum.map(&Attachment.prepared_components/1)
+    |> Enum.reduce([before: [], after: []], fn components, acc ->
+      Keyword.merge(acc, components, fn _k, v1, v2 -> v1 ++ v2 end)
+    end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/exactly/multi_measure_rest.ex
+++ b/lib/exactly/multi_measure_rest.ex
@@ -5,18 +5,18 @@ defmodule Exactly.MultiMeasureRest do
 
   alias Exactly.Duration
 
-  defstruct [:duration]
+  defstruct [:written_duration, attachments: []]
 
   @type t :: %__MODULE__{
-          duration: Duration.t()
+          written_duration: Duration.t()
         }
 
   def new(duration \\ Duration.new(1)) do
-    %__MODULE__{duration: duration}
+    %__MODULE__{written_duration: duration}
   end
 
   defimpl String.Chars do
-    def to_string(%Exactly.MultiMeasureRest{duration: duration}) do
+    def to_string(%Exactly.MultiMeasureRest{written_duration: duration}) do
       "R" <> @protocol.to_string(duration)
     end
   end
@@ -34,6 +34,17 @@ defmodule Exactly.MultiMeasureRest do
   end
 
   defimpl Exactly.ToLilypond do
-    def to_lilypond(%Exactly.MultiMeasureRest{} = mm_rest), do: to_string(mm_rest)
+    import Exactly.Lilypond.Utils
+
+    def to_lilypond(%Exactly.MultiMeasureRest{} = mm_rest) do
+      %{before: attachments_before, after: attachments_after} = attachments_for(mm_rest)
+
+      [
+        attachments_before,
+        to_string(mm_rest),
+        Enum.map(attachments_after, &indent/1)
+      ]
+      |> concat()
+    end
   end
 end

--- a/lib/exactly/note.ex
+++ b/lib/exactly/note.ex
@@ -5,7 +5,7 @@ defmodule Exactly.Note do
 
   alias Exactly.{Duration, Notehead, Pitch}
 
-  defstruct [:written_duration, :notehead]
+  defstruct [:written_duration, :notehead, attachments: []]
 
   @type t :: %__MODULE__{
           written_duration: Duration.t(),
@@ -47,8 +47,17 @@ defmodule Exactly.Note do
   end
 
   defimpl Exactly.ToLilypond do
+    import Exactly.Lilypond.Utils
+
     def to_lilypond(%Exactly.Note{} = note) do
-      to_string(note)
+      %{before: attachments_before, after: attachments_after} = attachments_for(note)
+
+      [
+        attachments_before,
+        to_string(note),
+        Enum.map(attachments_after, &indent/1)
+      ]
+      |> concat()
     end
   end
 end

--- a/lib/exactly/rest.ex
+++ b/lib/exactly/rest.ex
@@ -5,7 +5,7 @@ defmodule Exactly.Rest do
 
   alias Exactly.Duration
 
-  defstruct [:written_duration]
+  defstruct [:written_duration, attachments: []]
 
   @type t :: %__MODULE__{
           written_duration: Duration.t()
@@ -36,8 +36,17 @@ defmodule Exactly.Rest do
   end
 
   defimpl Exactly.ToLilypond do
+    import Exactly.Lilypond.Utils
+
     def to_lilypond(%Exactly.Rest{} = rest) do
-      to_string(rest)
+      %{before: attachments_before, after: attachments_after} = attachments_for(rest)
+
+      [
+        attachments_before,
+        to_string(rest),
+        Enum.map(attachments_after, &indent/1)
+      ]
+      |> concat()
     end
   end
 end

--- a/lib/exactly/skip.ex
+++ b/lib/exactly/skip.ex
@@ -5,7 +5,7 @@ defmodule Exactly.Skip do
 
   alias Exactly.Duration
 
-  defstruct [:written_duration]
+  defstruct [:written_duration, attachments: []]
 
   @type t :: %__MODULE__{
           written_duration: Duration.t()
@@ -19,7 +19,7 @@ defmodule Exactly.Skip do
 
   defimpl String.Chars do
     def to_string(%Exactly.Skip{written_duration: duration}) do
-      "r" <> @protocol.to_string(duration)
+      "s" <> @protocol.to_string(duration)
     end
   end
 
@@ -36,8 +36,17 @@ defmodule Exactly.Skip do
   end
 
   defimpl Exactly.ToLilypond do
+    import Exactly.Lilypond.Utils
+
     def to_lilypond(%Exactly.Skip{} = skip) do
-      to_string(skip)
+      %{before: attachments_before, after: attachments_after} = attachments_for(skip)
+
+      [
+        attachments_before,
+        to_string(skip),
+        Enum.map(attachments_after, &indent/1)
+      ]
+      |> concat()
     end
   end
 end

--- a/test/exactly/articulation_test.exs
+++ b/test/exactly/articulation_test.exs
@@ -1,0 +1,23 @@
+defmodule Exactly.ArticulationTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.Articulation
+
+  describe "new/1" do
+    test "creates an articulation with the given name" do
+      assert Articulation.new(:accent) == %Articulation{
+               name: :accent,
+               components: [
+                 after: ["\\accent"]
+               ]
+             }
+    end
+  end
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the articulation" do
+      articulation = Articulation.new(:staccato)
+      assert inspect(articulation) == "#Exactly.Articulation<staccato>"
+    end
+  end
+end

--- a/test/exactly/attachment_test.exs
+++ b/test/exactly/attachment_test.exs
@@ -1,0 +1,27 @@
+defmodule Exactly.AttachmentTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Articulation, Attachment}
+
+  describe "new/1" do
+    test "creates a new attachment with the given attachable and default settings" do
+      articulation = Articulation.new(:accent)
+      attachment = Attachment.new(articulation)
+
+      assert attachment.attachable == articulation
+      assert attachment.priority == 0
+      assert attachment.direction == :neutral
+    end
+  end
+
+  describe "new/2" do
+    test "can override priority and direction" do
+      articulation = Articulation.new(:accent)
+      attachment = Attachment.new(articulation, priority: 1, direction: :up)
+
+      assert attachment.attachable == articulation
+      assert attachment.priority == 1
+      assert attachment.direction == :up
+    end
+  end
+end

--- a/test/exactly/breath_mark_test.exs
+++ b/test/exactly/breath_mark_test.exs
@@ -1,0 +1,11 @@
+defmodule Exactly.BreathMarkTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.BreathMark
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the breath mark" do
+      assert inspect(BreathMark.new()) == "#Exactly.BreathMark<>"
+    end
+  end
+end

--- a/test/exactly/chord_test.exs
+++ b/test/exactly/chord_test.exs
@@ -1,7 +1,7 @@
 defmodule Exactly.ChordTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.{Chord, Duration, Pitch}
+  alias Exactly.{Articulation, Chord, Duration, Pitch}
 
   describe "new/1" do
     test "defaults duration to quarter note" do
@@ -61,6 +61,19 @@ defmodule Exactly.ChordTest do
 
     test "empty chords have a duration printed" do
       assert Chord.new() |> Exactly.to_lilypond() == "<>4"
+    end
+
+    test "attachments are printed" do
+      assert Chord.new([Pitch.new(), Pitch.new(2)])
+             |> Exactly.attach(Articulation.new(:accent), direction: :up)
+             |> Exactly.to_lilypond() ==
+               String.trim("""
+               <
+                 c
+                 e
+               >4
+                 ^ \\accent
+               """)
     end
   end
 end

--- a/test/exactly/laissez_vibrer_test.exs
+++ b/test/exactly/laissez_vibrer_test.exs
@@ -1,0 +1,25 @@
+defmodule Exactly.LaissezVibrerTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{LaissezVibrer, Note}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the laissez vibrer tie" do
+      assert inspect(LaissezVibrer.new()) == "#Exactly.LaissezVibrer<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string the laissez vibrer tie" do
+      note =
+        Note.new()
+        |> Exactly.attach(LaissezVibrer.new(), direction: :up)
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 ^ \\laissezVibrer
+               """)
+    end
+  end
+end

--- a/test/exactly/multi_measure_rest_test.exs
+++ b/test/exactly/multi_measure_rest_test.exs
@@ -1,12 +1,12 @@
 defmodule Exactly.MultiMeasureRestTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.{Duration, MultiMeasureRest}
+  alias Exactly.{Articulation, Duration, MultiMeasureRest}
 
   describe "new/0" do
     test "defaults to 'R1'" do
       assert MultiMeasureRest.new() == %MultiMeasureRest{
-               duration: %Duration{
+               written_duration: %Duration{
                  log: 0,
                  dots: 0
                }
@@ -17,7 +17,7 @@ defmodule Exactly.MultiMeasureRestTest do
   describe "new/1" do
     test "can set the duration" do
       assert MultiMeasureRest.new(Duration.new(1, 5)) == %MultiMeasureRest{
-               duration: %Duration{
+               written_duration: %Duration{
                  log: 0,
                  dots: 0,
                  scale: 5
@@ -47,6 +47,18 @@ defmodule Exactly.MultiMeasureRestTest do
 
       assert MultiMeasureRest.new(Duration.new(1, 0.3)) |> Exactly.to_lilypond() ==
                "R1*3/10"
+    end
+
+    test "correctly displays attachments" do
+      mmr =
+        MultiMeasureRest.new(Duration.new(1, 3))
+        |> Exactly.attach(Articulation.new(:staccatissimo), direction: :down)
+
+      assert Exactly.to_lilypond(mmr) ==
+               String.trim("""
+               R1*3
+                 _ \\staccatissimo
+               """)
     end
   end
 end

--- a/test/exactly/note_test.exs
+++ b/test/exactly/note_test.exs
@@ -1,7 +1,7 @@
 defmodule Exactly.NoteTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.{Duration, Note, Notehead, Pitch}
+  alias Exactly.{Articulation, Duration, Note, Notehead, Pitch}
 
   describe "new/0" do
     test "defaults to c'4" do
@@ -53,6 +53,18 @@ defmodule Exactly.NoteTest do
     test "returns the correct Lilypond string for the note" do
       assert Note.new(Pitch.new(2, -0.5, -2), Duration.new(3 / 2)) |> Exactly.to_lilypond() ==
                "ef,,1."
+    end
+
+    test "correctly displays attachments" do
+      note =
+        Note.new()
+        |> Exactly.attach(Articulation.new(:accent))
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 - \\accent
+               """)
     end
   end
 end

--- a/test/exactly/rest_test.exs
+++ b/test/exactly/rest_test.exs
@@ -1,7 +1,7 @@
 defmodule Exactly.RestTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.{Duration, Rest}
+  alias Exactly.{BreathMark, Duration, Rest}
 
   describe "new/0" do
     test "defaults to r4" do
@@ -28,6 +28,18 @@ defmodule Exactly.RestTest do
   describe "to_lilypond/1" do
     test "returns the correct Lilypond string for the rest" do
       assert Rest.new(Duration.new(8)) |> Exactly.to_lilypond() == "r\\maxima"
+    end
+
+    test "can display attachments" do
+      rest =
+        Rest.new(Duration.new(1 / 4))
+        |> Exactly.attach(BreathMark.new())
+
+      assert Exactly.to_lilypond(rest) ==
+               String.trim("""
+               r4
+                 \\breathe
+               """)
     end
   end
 end

--- a/test/exactly/skip_test.exs
+++ b/test/exactly/skip_test.exs
@@ -1,7 +1,7 @@
 defmodule Exactly.SkipTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.{Duration, Skip}
+  alias Exactly.{Articulation, Duration, Skip}
 
   describe "new/0" do
     test "defaults to r4" do
@@ -21,13 +21,25 @@ defmodule Exactly.SkipTest do
 
   describe "inspect/1" do
     test "returns an IEx-ready represenation of the skip" do
-      assert Skip.new(Duration.new(7 / 32)) |> inspect() == "#Exactly.Skip<r8..>"
+      assert Skip.new(Duration.new(7 / 32)) |> inspect() == "#Exactly.Skip<s8..>"
     end
   end
 
   describe "to_lilypond/1" do
     test "returns the correct Lilypond string for the skip" do
-      assert Skip.new(Duration.new(8)) |> Exactly.to_lilypond() == "r\\maxima"
+      assert Skip.new(Duration.new(8)) |> Exactly.to_lilypond() == "s\\maxima"
+    end
+
+    test "correctly displays attachments" do
+      skip =
+        Skip.new(Duration.new(1))
+        |> Exactly.attach(Articulation.new(:tenuto))
+
+      assert Exactly.to_lilypond(skip) ==
+               String.trim("""
+               s1
+                 - \\tenuto
+               """)
     end
   end
 end


### PR DESCRIPTION
- Add `Attachment` struct and `use Exactly.Attachable`
- Add `Exactly.attach/3`
- Add `Articulation`, `BreathMark`, `LaissezVibrer`
- Implement displaying attachments for leaf-type structs

Also
===

- Fix bug in string representation of skip rests
- Convert MultiMeasureRest.duration to MultiMeasureRest.written_duration
