### PR TITLE
Add Start/Stop pairs of attachable types

### DIFF
--- a/lib/exactly/attachable.ex
+++ b/lib/exactly/attachable.ex
@@ -22,6 +22,15 @@ defmodule Exactly.Attachable do
       defimpl Exactly.HasDirection do
         def has_direction(_), do: unquote(has_direction)
       end
+
+      if unquote(fields) == [] do
+        defimpl Inspect do
+          def inspect(%@for{}, _opts) do
+            module_name = Module.split(@for) |> Enum.join(".")
+            "##{module_name}<>"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/exactly/attachment.ex
+++ b/lib/exactly/attachment.ex
@@ -16,14 +16,15 @@ defmodule Exactly.Attachment do
   def prepared_components(%__MODULE__{attachable: %{components: components}, direction: direction}) do
     components
     |> Enum.map(fn {k, v} ->
-      {k, Enum.map(v, &with_direction(&1, direction))}
+      {k, Enum.map(v, &with_direction(&1, k, direction))}
     end)
   end
 
-  defp with_direction(str, nil), do: str
-  defp with_direction(str, :neutral), do: "- #{str}"
-  defp with_direction(str, :up), do: "^ #{str}"
-  defp with_direction(str, :down), do: "_ #{str}"
+  defp with_direction(str, :before, _), do: str
+  defp with_direction(str, _, nil), do: str
+  defp with_direction(str, _, :neutral), do: "- #{str}"
+  defp with_direction(str, _, :up), do: "^ #{str}"
+  defp with_direction(str, _, :down), do: "_ #{str}"
 
   defp attachable_direction(attachable, opts) do
     case Exactly.HasDirection.has_direction(attachable) do

--- a/lib/exactly/laissez_vibrer.ex
+++ b/lib/exactly/laissez_vibrer.ex
@@ -10,8 +10,4 @@ defmodule Exactly.LaissezVibrer do
       components: [after: ["\\laissezVibrer"]]
     }
   end
-
-  defimpl Inspect do
-    def inspect(%@for{}, _opts), do: "#Exactly.LaissezVibrer<>"
-  end
 end

--- a/lib/exactly/start_beam.ex
+++ b/lib/exactly/start_beam.ex
@@ -1,0 +1,13 @@
+defmodule Exactly.StartBeam do
+  @moduledoc """
+  Models the beginning of a specified beam
+  """
+
+  use Exactly.Attachable
+
+  def new do
+    %__MODULE__{
+      components: [after: ["["]]
+    }
+  end
+end

--- a/lib/exactly/start_hairpin.ex
+++ b/lib/exactly/start_hairpin.ex
@@ -1,0 +1,28 @@
+defmodule Exactly.StartHairpin do
+  @moduledoc """
+  Models the beginning of a hairpin
+  """
+
+  use Exactly.Attachable, fields: [:shape]
+
+  @valid_shapes ~w(< >)a
+
+  def new(shape \\ :<) when shape in @valid_shapes do
+    %__MODULE__{
+      shape: shape,
+      components: [after: ["\\#{shape}"]]
+    }
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{shape: shape}, _opts) do
+      concat([
+        "#Exactly.StartHairpin<",
+        "\"#{to_string(shape)}\"",
+        ">"
+      ])
+    end
+  end
+end

--- a/lib/exactly/start_phrasing_slur.ex
+++ b/lib/exactly/start_phrasing_slur.ex
@@ -1,0 +1,13 @@
+defmodule Exactly.StartPhrasingSlur do
+  @moduledoc """
+  Models the beginning of a phrasing slur
+  """
+
+  use Exactly.Attachable
+
+  def new do
+    %__MODULE__{
+      components: [after: ["\\("]]
+    }
+  end
+end

--- a/lib/exactly/start_piano_pedal.ex
+++ b/lib/exactly/start_piano_pedal.ex
@@ -1,0 +1,32 @@
+defmodule Exactly.StartPianoPedal do
+  @moduledoc """
+  Models a pedal down marking
+  """
+
+  use Exactly.Attachable, has_direction: false, fields: [:pedal]
+
+  @valid_pedals ~w(sustain sostenuto corda)a
+
+  def new(pedal \\ :sustain) when pedal in @valid_pedals do
+    %__MODULE__{
+      pedal: pedal,
+      components: [after: [pedal_component(pedal)]]
+    }
+  end
+
+  defp pedal_component(:sustain), do: "\\sustainOn"
+  defp pedal_component(:sostenuto), do: "\\sostenutoOn"
+  defp pedal_component(:corda), do: "\\unaCorda"
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{pedal: pedal}, _opts) do
+      concat([
+        "#Exactly.StartPianoPedal<",
+        to_string(pedal),
+        ">"
+      ])
+    end
+  end
+end

--- a/lib/exactly/start_slur.ex
+++ b/lib/exactly/start_slur.ex
@@ -1,0 +1,13 @@
+defmodule Exactly.StartSlur do
+  @moduledoc """
+  Models the beginning of a slur
+  """
+
+  use Exactly.Attachable
+
+  def new do
+    %__MODULE__{
+      components: [after: ["("]]
+    }
+  end
+end

--- a/lib/exactly/start_trill_span.ex
+++ b/lib/exactly/start_trill_span.ex
@@ -1,0 +1,45 @@
+defmodule Exactly.StartTrillSpan do
+  @moduledoc """
+  Models the beginning of a trill span
+  """
+
+  use Exactly.Attachable, fields: [:trill_pitch]
+
+  def new(opts \\ []) do
+    trill_pitch = Keyword.get(opts, :trill_pitch, nil)
+
+    %__MODULE__{
+      trill_pitch: trill_pitch,
+      components: build_components(trill_pitch)
+    }
+  end
+
+  defp build_components(nil) do
+    [
+      before: [],
+      after: ["\\startTrillSpan"]
+    ]
+  end
+
+  defp build_components(pitch) do
+    [
+      before: ["\\pitchedTrill"],
+      after: ["\\startTrillSpan #{to_string(pitch)}"]
+    ]
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{trill_pitch: trill_pitch}, _opts) do
+      concat([
+        "#Exactly.StartTrillSpan<",
+        inspect_trill_pitch(trill_pitch),
+        ">"
+      ])
+    end
+
+    defp inspect_trill_pitch(nil), do: ""
+    defp inspect_trill_pitch(trill_pitch), do: to_string(trill_pitch)
+  end
+end

--- a/lib/exactly/stop_beam.ex
+++ b/lib/exactly/stop_beam.ex
@@ -1,13 +1,13 @@
-defmodule Exactly.BreathMark do
+defmodule Exactly.StopBeam do
   @moduledoc """
-  Models a Lilypond breath mark
+  Models the end of a specified beam
   """
 
   use Exactly.Attachable, has_direction: false
 
   def new do
     %__MODULE__{
-      components: [after: ["\\breathe"]]
+      components: [after: ["]"]]
     }
   end
 end

--- a/lib/exactly/stop_hairpin.ex
+++ b/lib/exactly/stop_hairpin.ex
@@ -1,13 +1,13 @@
-defmodule Exactly.BreathMark do
+defmodule Exactly.StopHairpin do
   @moduledoc """
-  Models a Lilypond breath mark
+  Models the end of a hairpin
   """
 
   use Exactly.Attachable, has_direction: false
 
   def new do
     %__MODULE__{
-      components: [after: ["\\breathe"]]
+      components: [after: ["\\!"]]
     }
   end
 end

--- a/lib/exactly/stop_phrasing_slur.ex
+++ b/lib/exactly/stop_phrasing_slur.ex
@@ -1,13 +1,13 @@
-defmodule Exactly.BreathMark do
+defmodule Exactly.StopPhrasingSlur do
   @moduledoc """
-  Models a Lilypond breath mark
+  Models the end of a phrasing slur
   """
 
   use Exactly.Attachable, has_direction: false
 
   def new do
     %__MODULE__{
-      components: [after: ["\\breathe"]]
+      components: [after: ["\\)"]]
     }
   end
 end

--- a/lib/exactly/stop_piano_pedal.ex
+++ b/lib/exactly/stop_piano_pedal.ex
@@ -1,0 +1,32 @@
+defmodule Exactly.StopPianoPedal do
+  @moduledoc """
+  Models a pedal up marking
+  """
+
+  use Exactly.Attachable, has_direction: false, fields: [:pedal]
+
+  @valid_pedals ~w(sustain sostenuto corda)a
+
+  def new(pedal \\ :sustain) when pedal in @valid_pedals do
+    %__MODULE__{
+      pedal: pedal,
+      components: [after: [pedal_component(pedal)]]
+    }
+  end
+
+  defp pedal_component(:sustain), do: "\\sustainOff"
+  defp pedal_component(:sostenuto), do: "\\sostenutoOff"
+  defp pedal_component(:corda), do: "\\treCorde"
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{pedal: pedal}, _opts) do
+      concat([
+        "#Exactly.StopPianoPedal<",
+        to_string(pedal),
+        ">"
+      ])
+    end
+  end
+end

--- a/lib/exactly/stop_slur.ex
+++ b/lib/exactly/stop_slur.ex
@@ -1,13 +1,13 @@
-defmodule Exactly.BreathMark do
+defmodule Exactly.StopSlur do
   @moduledoc """
-  Models a Lilypond breath mark
+  Models the end of a slur
   """
 
   use Exactly.Attachable, has_direction: false
 
   def new do
     %__MODULE__{
-      components: [after: ["\\breathe"]]
+      components: [after: [")"]]
     }
   end
 end

--- a/lib/exactly/stop_trill_span.ex
+++ b/lib/exactly/stop_trill_span.ex
@@ -1,13 +1,13 @@
-defmodule Exactly.BreathMark do
+defmodule Exactly.StopTrillSpan do
   @moduledoc """
-  Models a Lilypond breath mark
+  Models the end of a trill span
   """
 
   use Exactly.Attachable, has_direction: false
 
   def new do
     %__MODULE__{
-      components: [after: ["\\breathe"]]
+      components: [after: ["\\stopTrillSpan"]]
     }
   end
 end

--- a/test/exactly/laissez_vibrer_test.exs
+++ b/test/exactly/laissez_vibrer_test.exs
@@ -10,7 +10,7 @@ defmodule Exactly.LaissezVibrerTest do
   end
 
   describe "to_lilypond/1" do
-    test "returns the correct Lilypond string the laissez vibrer tie" do
+    test "returns the correct Lilypond string for the laissez vibrer tie" do
       note =
         Note.new()
         |> Exactly.attach(LaissezVibrer.new(), direction: :up)

--- a/test/exactly/start_beam_test.exs
+++ b/test/exactly/start_beam_test.exs
@@ -1,0 +1,25 @@
+defmodule Exactly.StartBeamTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Duration, Note, Pitch, StartBeam}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the start beam" do
+      assert inspect(StartBeam.new()) == "#Exactly.StartBeam<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the start beam" do
+      note =
+        Note.new(Pitch.new(), Duration.new(1 / 8))
+        |> Exactly.attach(StartBeam.new(), direction: :down)
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c8
+                 _ [
+               """)
+    end
+  end
+end

--- a/test/exactly/start_hairpin_test.exs
+++ b/test/exactly/start_hairpin_test.exs
@@ -1,0 +1,40 @@
+defmodule StartHairpinTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, StartHairpin}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the start hairpin" do
+      assert inspect(StartHairpin.new()) == "#Exactly.StartHairpin<\"<\">"
+
+      assert inspect(StartHairpin.new(:<)) == "#Exactly.StartHairpin<\"<\">"
+      assert inspect(StartHairpin.new(:>)) == "#Exactly.StartHairpin<\">\">"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the default start hairpin" do
+      note =
+        Note.new()
+        |> Exactly.attach(StartHairpin.new())
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 - \\<
+               """)
+    end
+
+    test "returns the correct Lilypond string for a diminuendo start hairpin" do
+      note =
+        Note.new()
+        |> Exactly.attach(StartHairpin.new(:>), direction: :up)
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 ^ \\>
+               """)
+    end
+  end
+end

--- a/test/exactly/start_phrasing_slur_test.exs
+++ b/test/exactly/start_phrasing_slur_test.exs
@@ -1,0 +1,25 @@
+defmodule Exactly.StartPhrasingSlurTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, StartPhrasingSlur}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the start of the phrasing slur" do
+      assert inspect(StartPhrasingSlur.new()) == "#Exactly.StartPhrasingSlur<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the start of the phrasing slur" do
+      note =
+        Note.new()
+        |> Exactly.attach(StartPhrasingSlur.new())
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 - \\(
+               """)
+    end
+  end
+end

--- a/test/exactly/start_piano_pedal_test.exs
+++ b/test/exactly/start_piano_pedal_test.exs
@@ -1,0 +1,49 @@
+defmodule Exactly.StartPianoPedalTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, StartPianoPedal}
+
+  describe "new/0" do
+    test "defaults to the sustain pedal" do
+      assert StartPianoPedal.new() == %StartPianoPedal{
+               pedal: :sustain,
+               components: [
+                 after: ["\\sustainOn"]
+               ]
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "can take another pedal type as an argument" do
+      assert StartPianoPedal.new(:corda) == %StartPianoPedal{
+               pedal: :corda,
+               components: [
+                 after: ["\\unaCorda"]
+               ]
+             }
+    end
+  end
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the pedal start" do
+      pedal = StartPianoPedal.new(:sostenuto)
+
+      assert inspect(pedal) == "#Exactly.StartPianoPedal<sostenuto>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the pedal start" do
+      note =
+        Note.new()
+        |> Exactly.attach(StartPianoPedal.new())
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 \\sustainOn
+               """)
+    end
+  end
+end

--- a/test/exactly/start_slur_test.exs
+++ b/test/exactly/start_slur_test.exs
@@ -1,0 +1,25 @@
+defmodule Exactly.StartSlurTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, StartSlur}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the start of the slur" do
+      assert inspect(StartSlur.new()) == "#Exactly.StartSlur<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the start of the slur" do
+      note =
+        Note.new()
+        |> Exactly.attach(StartSlur.new())
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 - (
+               """)
+    end
+  end
+end

--- a/test/exactly/start_trill_span_test.exs
+++ b/test/exactly/start_trill_span_test.exs
@@ -1,0 +1,68 @@
+defmodule Exactly.StartTrillSpanTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, Pitch, StartTrillSpan}
+
+  describe "new/0" do
+    test "creates a default trill span start" do
+      assert StartTrillSpan.new() == %StartTrillSpan{
+               trill_pitch: nil,
+               components: [
+                 before: [],
+                 after: ["\\startTrillSpan"]
+               ]
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "can define a pitched trill span via options" do
+      assert StartTrillSpan.new(trill_pitch: Pitch.new()) == %StartTrillSpan{
+               trill_pitch: Pitch.new(),
+               components: [
+                 before: ["\\pitchedTrill"],
+                 after: ["\\startTrillSpan c"]
+               ]
+             }
+    end
+  end
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of an unpitched trill span" do
+      trill = StartTrillSpan.new()
+      assert inspect(trill) == "#Exactly.StartTrillSpan<>"
+    end
+
+    test "returns an IEx-ready represenation of a pitched trill span" do
+      trill = StartTrillSpan.new(trill_pitch: Pitch.new(1, -0.5, 1))
+      assert inspect(trill) == "#Exactly.StartTrillSpan<df'>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for an unpitched trill span" do
+      note =
+        Note.new()
+        |> Exactly.attach(StartTrillSpan.new())
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 - \\startTrillSpan
+               """)
+    end
+
+    test "returns the correct Lilypond string for pitched trill span" do
+      note =
+        Note.new()
+        |> Exactly.attach(StartTrillSpan.new(trill_pitch: Pitch.new(1)), direction: :down)
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               \\pitchedTrill
+               c4
+                 _ \\startTrillSpan d
+               """)
+    end
+  end
+end

--- a/test/exactly/stop_beam_test.exs
+++ b/test/exactly/stop_beam_test.exs
@@ -1,0 +1,25 @@
+defmodule Exactly.StopBeamTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Duration, Note, Pitch, StopBeam}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the stop beam" do
+      assert inspect(StopBeam.new()) == "#Exactly.StopBeam<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the stop beam" do
+      note =
+        Note.new(Pitch.new(), Duration.new(1 / 8))
+        |> Exactly.attach(StopBeam.new(), direction: :down)
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c8
+                 ]
+               """)
+    end
+  end
+end

--- a/test/exactly/stop_hairpin_test.exs
+++ b/test/exactly/stop_hairpin_test.exs
@@ -1,0 +1,25 @@
+defmodule Exactly.StopHairpinTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, StopHairpin}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the stop hairpin" do
+      assert inspect(StopHairpin.new()) == "#Exactly.StopHairpin<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the stop hairpin" do
+      note =
+        Note.new()
+        |> Exactly.attach(StopHairpin.new(), direction: :up)
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 \\!
+               """)
+    end
+  end
+end

--- a/test/exactly/stop_phrasing_slur_test.exs
+++ b/test/exactly/stop_phrasing_slur_test.exs
@@ -1,0 +1,25 @@
+defmodule Exactly.StopPhrasingSlurTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, StopPhrasingSlur}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the stop phrasing slur" do
+      assert inspect(StopPhrasingSlur.new()) == "#Exactly.StopPhrasingSlur<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the stop phrasing slur" do
+      note =
+        Note.new()
+        |> Exactly.attach(StopPhrasingSlur.new())
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 \\)
+               """)
+    end
+  end
+end

--- a/test/exactly/stop_piano_pedal_test.exs
+++ b/test/exactly/stop_piano_pedal_test.exs
@@ -1,0 +1,49 @@
+defmodule Exactly.StopPianoPedalTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, StopPianoPedal}
+
+  describe "new/0" do
+    test "defaults to the sustain pedal" do
+      assert StopPianoPedal.new() == %StopPianoPedal{
+               pedal: :sustain,
+               components: [
+                 after: ["\\sustainOff"]
+               ]
+             }
+    end
+  end
+
+  describe "new/1" do
+    test "can take another pedal type as an argument" do
+      assert StopPianoPedal.new(:corda) == %StopPianoPedal{
+               pedal: :corda,
+               components: [
+                 after: ["\\treCorde"]
+               ]
+             }
+    end
+  end
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the pedal stop" do
+      pedal = StopPianoPedal.new(:sostenuto)
+
+      assert inspect(pedal) == "#Exactly.StopPianoPedal<sostenuto>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the pedal stop" do
+      note =
+        Note.new()
+        |> Exactly.attach(StopPianoPedal.new(:sostenuto))
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 \\sostenutoOff
+               """)
+    end
+  end
+end

--- a/test/exactly/stop_slur_test.exs
+++ b/test/exactly/stop_slur_test.exs
@@ -1,0 +1,25 @@
+defmodule Exactly.StopSlurTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.{Note, StopSlur}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the stop slur" do
+      assert inspect(StopSlur.new()) == "#Exactly.StopSlur<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the stop slur" do
+      note =
+        Note.new()
+        |> Exactly.attach(StopSlur.new())
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 )
+               """)
+    end
+  end
+end

--- a/test/exactly/stop_trill_span_test.exs
+++ b/test/exactly/stop_trill_span_test.exs
@@ -1,0 +1,27 @@
+defmodule Exactly.StopTrillSpanTest do
+  use ExUnit.Case, async: true
+
+  alias Exactly.StopTrillSpan
+
+  alias Exactly.{Note, StopTrillSpan}
+
+  describe "inspect/1" do
+    test "returns an IEx-ready represenation of the stop trill span" do
+      assert inspect(StopTrillSpan.new()) == "#Exactly.StopTrillSpan<>"
+    end
+  end
+
+  describe "to_lilypond/1" do
+    test "returns the correct Lilypond string for the stop trill span" do
+      note =
+        Note.new()
+        |> Exactly.attach(StopTrillSpan.new())
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+                 \\stopTrillSpan
+               """)
+    end
+  end
+end


### PR DESCRIPTION
- StartBeam and StopBeam
- StartHairpin and StopHairpin
- StartPhrasingSlur and StopPhrasingSlur
- StartSlur and StopSlur
- StartPianoPedal and StopPianoPedal

Also
===

- Fix test name for LaissezVibrer test
- Extract shared `Inspect` implementation for attachables without any fields
- Don't set direction on `before` attachments
