### PR TITLE
Refactor Barline, Clef, KeySignature and TimeSignature to be attachables

### DIFF
--- a/lib/exactly/attachable.ex
+++ b/lib/exactly/attachable.ex
@@ -15,9 +15,12 @@ defmodule Exactly.Attachable do
   defmacro __using__(opts) do
     fields = Keyword.get(opts, :fields, [])
     has_direction = Keyword.get(opts, :has_direction, true)
+    should_indent = Keyword.get(opts, :should_indent, true)
 
     quote do
       defstruct [unquote_splicing(fields), :components]
+
+      def should_indent, do: unquote(should_indent)
 
       defimpl Exactly.HasDirection do
         def has_direction(_), do: unquote(has_direction)

--- a/lib/exactly/attachment.ex
+++ b/lib/exactly/attachment.ex
@@ -13,10 +13,18 @@ defmodule Exactly.Attachment do
     }
   end
 
-  def prepared_components(%__MODULE__{attachable: %{components: components}, direction: direction}) do
+  def prepared_components(%__MODULE__{
+        attachable: %attachable_struct{components: components},
+        direction: direction
+      }) do
     components
-    |> Enum.map(fn {k, v} ->
-      {k, Enum.map(v, &with_direction(&1, k, direction))}
+    |> Enum.map(fn
+      {:before, v} ->
+        {:before, Enum.map(v, &with_direction(&1, :before, direction))}
+
+      {:after, v} ->
+        {:after,
+         Enum.map(v, &{with_direction(&1, :after, direction), attachable_struct.should_indent()})}
     end)
   end
 

--- a/lib/exactly/barline.ex
+++ b/lib/exactly/barline.ex
@@ -5,16 +5,25 @@ defmodule Exactly.Barline do
 
   @valid_barlines ~w(| . || .| |. .. |.| ; ! ' , .|: :|. :..: :|.|: :|.: :.|.: [|: :|] :|][|:)
 
-  defstruct [:barline]
+  use Exactly.Attachable, has_direction: false, fields: [:barline], should_indent: false
 
   @type t :: %__MODULE__{
-          barline: String.t()
+          barline: String.t(),
+          components: Keyword.t()
         }
 
   def new(barline \\ "|") do
     case validate_barline(barline) do
-      {:ok, barline} -> %__MODULE__{barline: barline}
-      :error -> {:error, :invalid_barline, barline}
+      {:ok, barline} ->
+        %__MODULE__{
+          barline: barline,
+          components: [
+            after: ["\\bar \"#{barline}\""]
+          ]
+        }
+
+      :error ->
+        {:error, :invalid_barline, barline}
     end
   end
 
@@ -32,12 +41,6 @@ defmodule Exactly.Barline do
         @protocol.inspect(barline, opts),
         ">"
       ])
-    end
-  end
-
-  defimpl Exactly.ToLilypond do
-    def to_lilypond(%@for{barline: barline}) do
-      "\\bar \"#{barline}\""
     end
   end
 end

--- a/lib/exactly/chord.ex
+++ b/lib/exactly/chord.ex
@@ -68,7 +68,7 @@ defmodule Exactly.Chord do
           ">#{@protocol.to_lilypond(duration)}"
         ]
         |> concat(joiner),
-        Enum.map(attachments_after, &indent/1)
+        attachments_after
       ]
       |> concat()
     end

--- a/lib/exactly/key_signature.ex
+++ b/lib/exactly/key_signature.ex
@@ -5,7 +5,8 @@ defmodule Exactly.KeySignature do
 
   alias Exactly.Pitch
 
-  defstruct [:pitch, :mode]
+  # defstruct [:pitch, :mode]
+  use Exactly.Attachable, has_direction: false, fields: [:pitch, :mode]
 
   @valid_modes ~w(major minor dorian phrygian lydian mixolydian locrian ionian aeolian)a
 
@@ -28,7 +29,10 @@ defmodule Exactly.KeySignature do
       {:ok, mode} ->
         %__MODULE__{
           pitch: pitch,
-          mode: mode
+          mode: mode,
+          components: [
+            before: ["\\key #{pitch} \\#{mode}"]
+          ]
         }
 
       :error ->
@@ -50,12 +54,6 @@ defmodule Exactly.KeySignature do
         to_string(mode),
         ">"
       ])
-    end
-  end
-
-  defimpl Exactly.ToLilypond do
-    def to_lilypond(%@for{pitch: pitch, mode: mode}) do
-      "\\key #{to_string(pitch)} \\#{to_string(mode)}"
     end
   end
 end

--- a/lib/exactly/lilypond/utils.ex
+++ b/lib/exactly/lilypond/utils.ex
@@ -50,5 +50,11 @@ defmodule Exactly.Lilypond.Utils do
       Keyword.merge(acc, components, fn _k, v1, v2 -> v1 ++ v2 end)
     end)
     |> Enum.into(%{})
+    |> update_in([:after], fn as ->
+      Enum.map(as, fn
+        {attachment, true} -> indent(attachment)
+        {attachment, false} -> attachment
+      end)
+    end)
   end
 end

--- a/lib/exactly/note.ex
+++ b/lib/exactly/note.ex
@@ -55,7 +55,7 @@ defmodule Exactly.Note do
       [
         attachments_before,
         to_string(note),
-        Enum.map(attachments_after, &indent/1)
+        attachments_after
       ]
       |> concat()
     end

--- a/lib/exactly/rest.ex
+++ b/lib/exactly/rest.ex
@@ -44,7 +44,7 @@ defmodule Exactly.Rest do
       [
         attachments_before,
         to_string(rest),
-        Enum.map(attachments_after, &indent/1)
+        attachments_after
       ]
       |> concat()
     end

--- a/lib/exactly/skip.ex
+++ b/lib/exactly/skip.ex
@@ -44,7 +44,7 @@ defmodule Exactly.Skip do
       [
         attachments_before,
         to_string(skip),
-        Enum.map(attachments_after, &indent/1)
+        attachments_after
       ]
       |> concat()
     end

--- a/lib/exactly/time_signature.ex
+++ b/lib/exactly/time_signature.ex
@@ -3,15 +3,22 @@ defmodule Exactly.TimeSignature do
   Models a Lilypond time signature
   """
 
-  defstruct [:numerator, :denominator]
+  use Exactly.Attachable, has_direction: false, fields: [:numerator, :denominator]
 
   @type t :: %__MODULE__{
           numerator: integer(),
-          denominator: integer()
+          denominator: integer(),
+          components: Keyword.t()
         }
 
   def new(numerator, denominator) do
-    %__MODULE__{numerator: numerator, denominator: denominator}
+    %__MODULE__{
+      numerator: numerator,
+      denominator: denominator,
+      components: [
+        before: ["\\time #{numerator}/#{denominator}"]
+      ]
+    }
   end
 
   defimpl Inspect do
@@ -23,12 +30,6 @@ defmodule Exactly.TimeSignature do
         "#{n}/#{d}",
         ">"
       ])
-    end
-  end
-
-  defimpl Exactly.ToLilypond do
-    def to_lilypond(%@for{numerator: n, denominator: d}) do
-      "\\time #{n}/#{d}"
     end
   end
 end

--- a/test/exactly/barline_test.exs
+++ b/test/exactly/barline_test.exs
@@ -1,17 +1,17 @@
 defmodule Exactly.BarlineTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.Barline
+  alias Exactly.{Barline, Note}
 
   describe "new/0" do
     test "defaults to a regular | barline" do
-      assert Barline.new() == %Barline{barline: "|"}
+      assert Barline.new() == %Barline{barline: "|", components: [after: ["\\bar \"|\""]]}
     end
   end
 
   describe "new/1" do
     test "returns a Barline when a valid barline is given" do
-      assert Barline.new(".") == %Barline{barline: "."}
+      assert Barline.new(".") == %Barline{barline: ".", components: [after: ["\\bar \".\""]]}
     end
 
     test "returns an error tuple when an invalid barline is given" do
@@ -19,7 +19,7 @@ defmodule Exactly.BarlineTest do
     end
 
     test "the empty string is a valid barline" do
-      assert Barline.new("") == %Barline{barline: ""}
+      assert Barline.new("") == %Barline{barline: "", components: [after: ["\\bar \"\""]]}
     end
   end
 
@@ -35,7 +35,15 @@ defmodule Exactly.BarlineTest do
 
   describe "to_lilypond/1" do
     test "returns the correct Lilypond string for the barline" do
-      assert Barline.new(":|.|:") |> Exactly.to_lilypond() == "\\bar \":|.|:\""
+      note =
+        Note.new()
+        |> Exactly.attach(Barline.new(":|.|:"))
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               c4
+               \\bar ":|.|:"
+               """)
     end
   end
 end

--- a/test/exactly/key_signature_test.exs
+++ b/test/exactly/key_signature_test.exs
@@ -1,7 +1,7 @@
 defmodule Exactly.KeySignatureTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.{KeySignature, Pitch}
+  alias Exactly.{KeySignature, Note, Pitch}
 
   describe "new/1" do
     test "mode defaults to major" do
@@ -11,7 +11,10 @@ defmodule Exactly.KeySignatureTest do
                  alter: 0,
                  octave: 0
                },
-               mode: :major
+               mode: :major,
+               components: [
+                 before: ["\\key c \\major"]
+               ]
              }
     end
   end
@@ -24,7 +27,10 @@ defmodule Exactly.KeySignatureTest do
                  alter: 0,
                  octave: 0
                },
-               mode: :minor
+               mode: :minor,
+               components: [
+                 before: ["\\key d \\minor"]
+               ]
              }
     end
 
@@ -43,8 +49,15 @@ defmodule Exactly.KeySignatureTest do
 
   describe "to_lilypond/1" do
     test "returns the correct Lilypond string for the keysignature" do
-      key_sig = KeySignature.new(Pitch.new(3, 0.5), :lydian)
-      assert Exactly.to_lilypond(key_sig) == "\\key fs \\lydian"
+      note =
+        Note.new()
+        |> Exactly.attach(KeySignature.new(Pitch.new(3, 0.5), :lydian))
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               \\key fs \\lydian
+               c4
+               """)
     end
   end
 end

--- a/test/exactly/time_signature_test.exs
+++ b/test/exactly/time_signature_test.exs
@@ -1,11 +1,17 @@
 defmodule Exactly.TimeSignatureTest do
   use ExUnit.Case, async: true
 
-  alias Exactly.TimeSignature
+  alias Exactly.{Note, TimeSignature}
 
   describe "new/2" do
     test "returns a time signature holding a basic fraction" do
-      assert TimeSignature.new(2, 4) == %TimeSignature{numerator: 2, denominator: 4}
+      assert TimeSignature.new(2, 4) == %TimeSignature{
+               numerator: 2,
+               denominator: 4,
+               components: [
+                 before: ["\\time 2/4"]
+               ]
+             }
     end
   end
 
@@ -17,7 +23,15 @@ defmodule Exactly.TimeSignatureTest do
 
   describe "to_lilypond/1" do
     test "returns the correct Lilypond string for the time signature" do
-      assert TimeSignature.new(3, 8) |> Exactly.to_lilypond() == "\\time 3/8"
+      note =
+        Note.new()
+        |> Exactly.attach(TimeSignature.new(3, 8))
+
+      assert Exactly.to_lilypond(note) ==
+               String.trim("""
+               \\time 3/8
+               c4
+               """)
     end
   end
 end


### PR DESCRIPTION
Also
===

- Allow specifying not indenting some attachables

This is kind of a messy solution, so maybe think about a `Components`
struct to hold this information in a more queryable way without
polluting the attachable structs with protocols?
